### PR TITLE
Change API URL from glitch.me to click

### DIFF
--- a/simple-grocery-store-openapi.yaml
+++ b/simple-grocery-store-openapi.yaml
@@ -2,11 +2,11 @@ openapi: 3.0.3
 info:
   title: Grocery Store API (Open API Spec)
   description: |
-    This API allows you to place a grocery order which will be ready for pick-up in the store. The API is available at https://simple-grocery-store-api.glitch.me
+    This API allows you to place a grocery order which will be ready for pick-up in the store. The API is available at https://simple-grocery-store-api.click
     A fuller description is located at (Simple Grocery Store API)[https://github.com/vdespa/Postman-Complete-Guide-API-Testing/blob/main/simple-grocery-store-api.md]
   version: 1.1.0
 servers:
-  - url: https://simple-grocery-store-api.glitch.me
+  - url: https://simple-grocery-store-api.click
 paths:
   /status:
     get:


### PR DESCRIPTION
Updated the API endpoint URL in the OpenAPI specification. I have imported the swagger yaml into postman and it was referencing old base url that was causing authentication issues.In the console i noticed url redirection was happening from .glitch.me to .click. after seeing one of your responses realized there is a change in base url. Creating this pull request so that if any other user directly imports the yaml, they will have the right baseurl. 